### PR TITLE
Rename pure to memo

### DIFF
--- a/apis/misc-apis.md
+++ b/apis/misc-apis.md
@@ -25,30 +25,33 @@ const Button = lazy(() => import ('./Button'))
 
 [Read more in the RFC](https://github.com/reactjs/rfcs/blob/gaearon-patch-2/text/0000-lazy.md)
 
-## `React.pure` Example
+## `React.memo` Example
 
-_Current API: `React.pure`_
+_Current API: `React.memo`_
 
-`React.pure` is a higher-order component version of the `React.PureComponent` class.
+`React.memo` is a higher-order component version of the `React.PureComponent` class.
 During an update, the previous props are compared to the new props.
 If they are the same, React will skip rendering the component and its children.
 
-Unlike userspace implementations, `pure` will not add an additional fiber to the tree.
+Unlike userspace implementations, `memo` will not add an additional fiber to the tree.
 
 The first argument must be a functional component; it does not work with classes.
 
-pure uses shallow comparison by default, like `React.PureComponent`.
+`memo` uses shallow comparison by default, like `React.PureComponent`.
 A custom comparison can be passed as the second argument.
 
 ```js
-const PureChildComponent = React.pure(ChildComponent);
+import React, { memo } from 'react';
+
+const areChildPropsEqual = (prevProps, nextProps) => prevProps.nested.id === nextProps.nested.id;
+const MemoChildComponent = memo(ChildComponent, areChildPropsEqual);
 ```
 
-[Read more in the RFC](https://github.com/reactjs/rfcs/blob/gaearon-patch-1/text/0000-pure.md).
+[Read more in the RFC](https://github.com/reactjs/rfcs/blob/gaearon-patch-1/text/0000-memo.md).
 
 ---
 
 **Recommended Sources for further info:**
 
-- [React.pure PR](https://github.com/facebook/react/pull/13748)
+- [React.memo PR](https://github.com/facebook/react/pull/13748) ([renamed from React.pure](https://github.com/facebook/react/pull/13905))
 - [React.lazy PR](https://github.com/facebook/react/pull/13398)


### PR DESCRIPTION
`React.pure` was recently renamed to `React.memo` (https://github.com/facebook/react/pull/13905) + added custom comparison to the example.