### PR TITLE
Deprecate "maxDuration" documentation as the prop is removed from "<Suspense>" #22

### DIFF
--- a/Timeline.md
+++ b/Timeline.md
@@ -74,6 +74,7 @@
 - 28 Apr 2019: React Batched Mode - mentions deprecating `ConcurrentMode` altogether - [PR](https://github.com/facebook/react/pull/15502) - [done in this PR](https://github.com/facebook/react/pull/15532)
 - 13 Apr 2019: About React Suspense and Concurrent Mode - [@pomber on Dev.to](https://dev.to/pomber/about-react-suspense-and-concurrent-mode-21aj)
 - 11 Apr 2019: New Fiber Scheduler rewrite - [Github PR](https://github.com/facebook/react/pull/15387)
+- 10 Apr 2019: A hueristic replacement of React.Suspense maxDuration uses [Just Noticeable Difference](https://github.com/facebook/react/pull/15367) to calculate the timeout after [removing hard-coded 150ms](https://github.com/facebook/react/pull/15367/files#diff-a409dc1b2c8ece1cc1fa28fe42b481ceL1829)
 - 4 Apr 2019: React.Suspense maxDuration attribute has been removed from Flow - [Github](https://github.com/facebook/flow/pull/7613)
 - 2 Apr 2019: React.Suspense maxDuration prop has been removed from React - [Github](https://github.com/facebook/react/pull/15272)
 - 19 Feb 2019: "Concurrent Mode is about prioritizing updates, not components. Components still update together. But CM lets certain updates interrupt other updates. And prevents React from blocking browser paint" - [Twitter](https://twitter.com/dan_abramov/status/1097831099730968576?s=12)

--- a/Timeline.md
+++ b/Timeline.md
@@ -30,8 +30,6 @@
 ## Code To Check Out
 
 - 30 Jun 2019: New SuspenseList Component - [Github](https://github.com/facebook/react/pull/15902), [forward and backward revealOrder](https://github.com/facebook/react/pull/15918), [swallowing tail](https://github.com/facebook/react/pull/15946)
-- 4 Apr 2019: React.Suspense maxDuration attribute has been removed from Flow - [Github](https://github.com/facebook/flow/pull/7613)
-- 2 Apr 2019: React.Suspense maxDuration prop has been removed from React - [Github](https://github.com/facebook/react/pull/15272)
 - 7 Jan 2019: React-aldrin by Fredrik Hoglund - Suspense based Server Renderer - [Github](https://github.com/Ephem/react-aldrin), [Twitter](https://twitter.com/EphemeralCircle/status/1082264727294758912)
 - 25 Oct 2018: Jared Palmer Suspensify ReactConf Demo of Suspense - [Github](https://github.com/jaredpalmer/react-conf-2018)
 - 24 Oct 2018: testing Suspense's maxDuration - [Github](https://github.com/kentcdodds/suspense-max-duration-issue?fbclid=IwAR1ZYaFXCplCK0O2hcHQXu1kVCNuVJ_-oxgkeZiBD8Zxz_dnerHJzSNs7uQ) and [Twitter](https://twitter.com/kentcdodds/status/1055292963545264128)
@@ -76,6 +74,8 @@
 - 28 Apr 2019: React Batched Mode - mentions deprecating `ConcurrentMode` altogether - [PR](https://github.com/facebook/react/pull/15502) - [done in this PR](https://github.com/facebook/react/pull/15532)
 - 13 Apr 2019: About React Suspense and Concurrent Mode - [@pomber on Dev.to](https://dev.to/pomber/about-react-suspense-and-concurrent-mode-21aj)
 - 11 Apr 2019: New Fiber Scheduler rewrite - [Github PR](https://github.com/facebook/react/pull/15387)
+- 4 Apr 2019: React.Suspense maxDuration attribute has been removed from Flow - [Github](https://github.com/facebook/flow/pull/7613)
+- 2 Apr 2019: React.Suspense maxDuration prop has been removed from React - [Github](https://github.com/facebook/react/pull/15272)
 - 19 Feb 2019: "Concurrent Mode is about prioritizing updates, not components. Components still update together. But CM lets certain updates interrupt other updates. And prevents React from blocking browser paint" - [Twitter](https://twitter.com/dan_abramov/status/1097831099730968576?s=12)
 - 20 Nov 2018: Jared Palmer on Hooks and Suspense on React Podcast - [Podcast](https://reactpodcast.com/29)
 - 4 Nov 2018: Metaphor for how Concurrent React works - illustrator with two queues - [Twitter](https://twitter.com/dan_abramov/status/1059059596835340288)

--- a/Timeline.md
+++ b/Timeline.md
@@ -30,7 +30,8 @@
 ## Code To Check Out
 
 - 30 Jun 2019: New SuspenseList Component - [Github](https://github.com/facebook/react/pull/15902), [forward and backward revealOrder](https://github.com/facebook/react/pull/15918), [swallowing tail](https://github.com/facebook/react/pull/15946)
-- 2 Apr 2019: maxDuration prop for Suspense component has been removed from React and Flow - [Github](https://github.com/facebook/react/pull/15272) (React), [Github](https://github.com/facebook/flow/pull/7613) (Flow)
+- 4 Apr 2019: React.Suspense maxDuration attribute has been removed from Flow - [Github](https://github.com/facebook/flow/pull/7613)
+- 2 Apr 2019: React.Suspense maxDuration prop has been removed from React - [Github](https://github.com/facebook/react/pull/15272)
 - 7 Jan 2019: React-aldrin by Fredrik Hoglund - Suspense based Server Renderer - [Github](https://github.com/Ephem/react-aldrin), [Twitter](https://twitter.com/EphemeralCircle/status/1082264727294758912)
 - 25 Oct 2018: Jared Palmer Suspensify ReactConf Demo of Suspense - [Github](https://github.com/jaredpalmer/react-conf-2018)
 - 24 Oct 2018: testing Suspense's maxDuration - [Github](https://github.com/kentcdodds/suspense-max-duration-issue?fbclid=IwAR1ZYaFXCplCK0O2hcHQXu1kVCNuVJ_-oxgkeZiBD8Zxz_dnerHJzSNs7uQ) and [Twitter](https://twitter.com/kentcdodds/status/1055292963545264128)

--- a/Timeline.md
+++ b/Timeline.md
@@ -30,6 +30,7 @@
 ## Code To Check Out
 
 - 30 Jun 2019: New SuspenseList Component - [Github](https://github.com/facebook/react/pull/15902), [forward and backward revealOrder](https://github.com/facebook/react/pull/15918), [swallowing tail](https://github.com/facebook/react/pull/15946)
+- 2 Apr 2019: maxDuration prop for Suspense component has been removed from React and Flow - [Github](https://github.com/facebook/react/pull/15272) (React), [Github](https://github.com/facebook/flow/pull/7613) (Flow)
 - 7 Jan 2019: React-aldrin by Fredrik Hoglund - Suspense based Server Renderer - [Github](https://github.com/Ephem/react-aldrin), [Twitter](https://twitter.com/EphemeralCircle/status/1082264727294758912)
 - 25 Oct 2018: Jared Palmer Suspensify ReactConf Demo of Suspense - [Github](https://github.com/jaredpalmer/react-conf-2018)
 - 24 Oct 2018: testing Suspense's maxDuration - [Github](https://github.com/kentcdodds/suspense-max-duration-issue?fbclid=IwAR1ZYaFXCplCK0O2hcHQXu1kVCNuVJ_-oxgkeZiBD8Zxz_dnerHJzSNs7uQ) and [Twitter](https://twitter.com/kentcdodds/status/1055292963545264128)

--- a/apis/react-suspense.md
+++ b/apis/react-suspense.md
@@ -16,8 +16,8 @@ React Suspense is a generic way for components to suspend rendering while they l
   - showing a **fallback** UI if the duration of the suspense exceeds a threshold
   - **resuming** render when the fetch is fulfilled and the cache read obtains a value
 - Render is only complete and committed to the DOM when either:
-  - a hueristic and different mechanism decides that a **fallback** UI is shown. React ships with [hard-coded built-in expiry limit of 150ms](https://github.com/facebook/react/pull/15272#issue-265972492).
-  - OR: all sibling and child suspenders within a `<Suspense>` boundary have resolved. In other words, they "render together or not at all".
+  - a hueristic ([Just Noticeable Difference](https://github.com/facebook/react/pull/15367)) decides that a **fallback** UI is shown
+  - OR: all sibling and child suspenders within a `<Suspense>` boundary have resolved. In other words, they "render together or not at all"
 
 Cache implementations are independent of React Suspense;
 the React team maintains a reference implementation called `react-cache`
@@ -27,7 +27,8 @@ Caches should be idempotent and should **throw promises** to resolve data fetche
 
 ~~## maxDuration is NOT actual Duration~~
 
-- Update 12 Jul 2019: maxDuration has been removed and [replaced with a heuristic and different mechanism instead](https://github.com/facebook/react/pull/15272)
+- Update 10 Apr 2019: A hueristic replacement of maxDuration uses [Just Noticeable Difference](https://github.com/facebook/react/pull/15367) to calculate the timeout after [removing hard-coded 150ms](https://github.com/facebook/react/pull/15367/files#diff-a409dc1b2c8ece1cc1fa28fe42b481ceL1829)
+- Update 4 Apr 2019: maxDuration has been removed and [replaced with a heuristic and different mechanism instead](https://github.com/facebook/react/pull/15272)
 - Update 27 Jan 2019: [maxDuration is too hard to explain, will be dropped for something else](https://twitter.com/sebmarkbage/status/1089704030920556549)
 
 ## `<Suspense>` Example

--- a/apis/react-suspense.md
+++ b/apis/react-suspense.md
@@ -31,7 +31,8 @@ This is not final but priorities have an associated duration that may supercede 
 
 Actual duration works like `Math.min(how long it took, maxDuration of Suspense, duration associated with priority of update)`.
 
-Update Jan 27 2019: [maxDuration is too hard to explain, will be dropped for something else](https://twitter.com/sebmarkbage/status/1089704030920556549)
+- Update 12 Jul 2019: maxDuration has been removed from [React](https://github.com/facebook/react/pull/15272) and [Flow](https://github.com/facebook/flow/pull/7613)
+- Update 27 Jan 2019: [maxDuration is too hard to explain, will be dropped for something else](https://twitter.com/sebmarkbage/status/1089704030920556549)
 
 ## `<Suspense>` Example
 

--- a/apis/react-suspense.md
+++ b/apis/react-suspense.md
@@ -25,8 +25,6 @@ that also supports key-based invalidation and preloading but they are not strict
 
 Caches should be idempotent and should **throw promises** to resolve data fetches.
 
-~~## maxDuration is NOT actual Duration~~
-
 - Update 10 Apr 2019: A hueristic replacement of maxDuration uses [Just Noticeable Difference](https://github.com/facebook/react/pull/15367) to calculate the timeout after [removing hard-coded 150ms](https://github.com/facebook/react/pull/15367/files#diff-a409dc1b2c8ece1cc1fa28fe42b481ceL1829)
 - Update 4 Apr 2019: maxDuration has been removed and [replaced with a heuristic and different mechanism instead](https://github.com/facebook/react/pull/15272)
 - Update 27 Jan 2019: [maxDuration is too hard to explain, will be dropped for something else](https://twitter.com/sebmarkbage/status/1089704030920556549)

--- a/apis/react-suspense.md
+++ b/apis/react-suspense.md
@@ -16,7 +16,7 @@ React Suspense is a generic way for components to suspend rendering while they l
   - showing a **fallback** UI if the duration of the suspense exceeds a threshold
   - **resuming** render when the fetch is fulfilled and the cache read obtains a value
 - Render is only complete and committed to the DOM when either:
-  - `maxDuration` is exceeded and the **fallback** UI is shown. React ships with built in maxDuration expiry limits (up to 5 seconds, iirc), and will use the smaller of the builtin limit or of whatever you specify (see below).
+  - a hueristic and different mechanism decides that a **fallback** UI is shown. React ships with [hard-coded built-in expiry limit of 150ms](https://github.com/facebook/react/pull/15272#issue-265972492).
   - OR: all sibling and child suspenders within a `<Suspense>` boundary have resolved. In other words, they "render together or not at all".
 
 Cache implementations are independent of React Suspense;
@@ -25,13 +25,9 @@ that also supports key-based invalidation and preloading but they are not strict
 
 Caches should be idempotent and should **throw promises** to resolve data fetches.
 
-## maxDuration is NOT actual Duration
+~~## maxDuration is NOT actual Duration~~
 
-This is not final but priorities have an associated duration that may supercede the duration you set. `ReactDOM.createRoot().render()` has normal priority (which means it is allowed to suspend for max 5 seconds). [Source](https://twitter.com/dan_abramov/status/1061344382375395329). Inside high priority "intentional" events it is 100ms in prod. [Source](https://twitter.com/dan_abramov/status/1055298410767675398?s=20)
-
-Actual duration works like `Math.min(how long it took, maxDuration of Suspense, duration associated with priority of update)`.
-
-- Update 12 Jul 2019: maxDuration has been removed from [React](https://github.com/facebook/react/pull/15272) and [Flow](https://github.com/facebook/flow/pull/7613)
+- Update 12 Jul 2019: maxDuration has been removed and [replaced with a heuristic and different mechanism instead](https://github.com/facebook/react/pull/15272)
 - Update 27 Jan 2019: [maxDuration is too hard to explain, will be dropped for something else](https://twitter.com/sebmarkbage/status/1089704030920556549)
 
 ## `<Suspense>` Example
@@ -42,12 +38,12 @@ _Current API: `React.Suspense`_
 
 ```js
 // inside render...
-<Suspense maxDuration={1000} fallback={<Spinner size="medium" />}>
+<Suspense fallback={<Spinner size="medium" />}>
   <ChildComponent id={id} />
 </Suspense>
 ```
 
-`<Suspense>` works outside of a Concurrent root, but will act as though `maxDuration` is always 0 (i.e. it will always show the fallback UI even if momentarily, just like in normal React)
+`<Suspense>` works outside of a Concurrent root (in 16.6.0~16.8.6), and will always show the fallback UI even if momentarily.
 
 Please see our `react-cache` section for how to write suspenders.
 


### PR DESCRIPTION
A PR for issue #22